### PR TITLE
fix freezing issues with large strings

### DIFF
--- a/.meta/114.md
+++ b/.meta/114.md
@@ -1,0 +1,5 @@
+## fix freezing issues with large strings
+
+By [@recurser](https://github.com/recurser)
+
+Created 2022-01-05 10:25

--- a/src/lib/identities/CssIdentity.ts
+++ b/src/lib/identities/CssIdentity.ts
@@ -1,4 +1,6 @@
 import { isEmpty } from 'lodash'
+import parserPostcss from 'prettier/parser-postcss'
+import { format } from 'prettier/standalone'
 
 import { Converter, CssFormatter } from '@lib/converters'
 
@@ -9,21 +11,10 @@ export const confidence = (input: string) => {
     return 0
   }
 
-  if (
-    // We must have at least a word with opening and closing brackets, with a semicolon inside.
-    // ([\.#]?[^{\s]+) : Anything that's not a space or a '{'
-    // [\s]*           : Optional spaces before the '{ ... }'
-    // {               : Open the brackets.
-    // [^\:]+:         : Anything that's not a ':', followed by a ':'.
-    // [^;]+;          : Anything that's not a ';', followed by a ';'.
-    // (.|\s)*         : Any number of characters / spaces / line breaks.
-    // }               : The closing bracket.
-    !/([\.#]?[^{\s]+)[\s]*{[^\:]+:[^;]+;(.|\s)*}/gm.test(input.trim())
-  ) {
-    return 0
-  }
+  // Prettier will throw an exception if this fails.
+  format(input, { parser: 'scss', plugins: [parserPostcss] })
 
-  // Let the LessFormatter and ScssFormatter take precedence, if they gets a match.
+  // Let the LessFormatter and ScssFormatter take precedence, if they get a match.
   return 80
 }
 

--- a/src/lib/identities/LessIdentity.ts
+++ b/src/lib/identities/LessIdentity.ts
@@ -1,32 +1,21 @@
 import { isEmpty } from 'lodash'
+import parserPostcss from 'prettier/parser-postcss'
+import { format } from 'prettier/standalone'
 
 import { Converter, LessFormatter } from '@lib/converters'
 
-export const id = 'scss'
+export const id = 'less'
 
 export const confidence = (input: string) => {
   if (isEmpty(input)) {
     return 0
   }
 
-  if (
-    // We must have at least a word with opening and closing brackets, with a semicolon inside.
-    // ([\.#]?[^{\s]+) : Anything that's not a space or a '{'
-    // [\s]*           : Optional spaces before the '{ ... }'
-    // {               : Open the brackets.
-    // [^\:]+:         : Anything that's not a ':', followed by a ':'.
-    // [^;]+;          : Anything that's not a ';', followed by a ';'.
-    // (.|\s)*         : Any number of characters / spaces / line breaks.
-    // (\.\w+\(\))     : A function call like .bordered() <-- THIS IS THE ONLY DIFFERENCE FROM THE CSS REGEX.
-    // }               : The closing bracket.
-    !/([\.#]?[^{\s]+)[\s]*{[^\:]+:[^;]+;(.|\s)*(\.\w+\(\))(.|\s)*}/gm.test(
-      input.trim(),
-    )
-  ) {
-    return 0
-  }
+  // Prettier will throw an exception if this fails.
+  format(input, { parser: 'less', plugins: [parserPostcss] })
 
-  return 100
+  // Let the ScssFormatter take precedence, if it gets a match.
+  return 90
 }
 
 export const converters = [LessFormatter] as Converter[]

--- a/src/lib/identities/ScssIdentity.ts
+++ b/src/lib/identities/ScssIdentity.ts
@@ -1,4 +1,6 @@
 import { isEmpty } from 'lodash'
+import parserPostcss from 'prettier/parser-postcss'
+import { format } from 'prettier/standalone'
 
 import { Converter, ScssFormatter } from '@lib/converters'
 
@@ -9,25 +11,10 @@ export const confidence = (input: string) => {
     return 0
   }
 
-  if (
-    // We must have at least a word with opening and closing brackets, with a semicolon inside.
-    // ([\.#]?[^{\s]+) : Anything that's not a space or a '{'
-    // [\s]*           : Optional spaces before the '{ ... }'
-    // {               : Open the brackets.
-    // [^\:]+:         : Anything that's not a ':', followed by a ':'.
-    // [^;]+;          : Anything that's not a ';', followed by a ';'.
-    // (.|\s)*         : Any number of characters / spaces / line breaks.
-    // [{}](.|\s)*     : An extra bracket nested inside somewhere. <-- THIS IS THE ONLY DIFFERENCE FROM THE CSS REGEX.
-    // }               : The closing bracket.
-    !/([\.#]?[^{\s]+)[\s]*{[^\:]+:[^;]+;(.|\s)*[{}](.|\s)*}/gm.test(
-      input.trim(),
-    )
-  ) {
-    return 0
-  }
+  // Prettier will throw an exception if this fails.
+  format(input, { parser: 'scss', plugins: [parserPostcss] })
 
-  // Let the LessFormatter take precedence, if it gets a match.
-  return 90
+  return 100
 }
 
 export const converters = [ScssFormatter] as Converter[]


### PR DESCRIPTION
Replace this with a detailed explanation of the change


## How to test the PR

Paste a long string (such as [this markdown](https://markdown-it.github.io/)) and make sure that the converter is chosen quickly, with no browser freeze.


## Checklist

- [x] New functionality has tests.
- [x] README has been updated (if necessary).
- [x] New environment variables have been added to `.env.example` (if necessary).