### PR TITLE
expand the output textarea for long strings

### DIFF
--- a/.meta/115.md
+++ b/.meta/115.md
@@ -1,0 +1,5 @@
+## expand the output textarea for long strings
+
+By [@recurser](https://github.com/recurser)
+
+Created 2022-01-05 11:07

--- a/src/components/forms/Form.tsx
+++ b/src/components/forms/Form.tsx
@@ -4,7 +4,12 @@ import { PropsWithChildren, ReactElement } from 'react'
 export const Form = ({
   children,
 }: PropsWithChildren<Record<string, unknown>>): ReactElement => (
-  <Pane display="flex" flexDirection="column" marginBottom={majorScale(1)}>
+  <Pane
+    display="flex"
+    flexDirection="column"
+    flexGrow={1}
+    marginBottom={majorScale(1)}
+  >
     {children}
   </Pane>
 )


### PR DESCRIPTION
Before:

<img width="2168" alt="Screen Shot 2022-01-05 at 22 36 55" src="https://user-images.githubusercontent.com/96322/148226480-82fadcc0-b3b9-4bf0-9c53-33738cb9bbb6.png">

After:

<img width="2168" alt="Screen Shot 2022-01-05 at 22 37 05" src="https://user-images.githubusercontent.com/96322/148226532-b2898c2d-dbd6-4398-8df1-442bf297dcec.png">


## How to test the PR

Paste a long string, and check that the right-hand output textarea expands to fill the screen.
