### PR TITLE
add showdown to the list of acknowledgements

### DIFF
--- a/.meta/117.md
+++ b/.meta/117.md
@@ -1,0 +1,5 @@
+## add showdown to the list of acknowledgements
+
+By [@recurser](https://github.com/recurser)
+
+Created 2022-01-05 15:40

--- a/src/components/pages/About.tsx
+++ b/src/components/pages/About.tsx
@@ -161,6 +161,12 @@ export const About = () => {
           </ListItem>
 
           <ListItem>
+            <Link href="https://github.com/showdownjs/showdown" target="_blank">
+              showdown
+            </Link>
+          </ListItem>
+
+          <ListItem>
             <Trans
               components={[
                 <Link


### PR DESCRIPTION
I forgot to acknowledge [showdown](https://github.com/showdownjs/showdown) in #117. 


## How to test the PR

Make sure that the [showdown](https://github.com/showdownjs/showdown) project is listed on the `/about` page.