### PR TITLE
Enable strikethrough for Markdown conversion

### DIFF
--- a/.meta/118.md
+++ b/.meta/118.md
@@ -1,0 +1,5 @@
+## enable strikethrough for Markdown conversion
+
+By [@recurser](https://github.com/recurser)
+
+Created 2022-01-05 15:59

--- a/src/lib/converters/MarkdownToHtmlConverter.ts
+++ b/src/lib/converters/MarkdownToHtmlConverter.ts
@@ -11,7 +11,7 @@ export const operation = (
   input: string,
   options: ConverterOptions = {},
 ): string => {
-  const converter = new Converter({ noHeaderId: true })
+  const converter = new Converter({ noHeaderId: true, strikethrough: true })
   const html = converter.makeHtml(input)
 
   return htmlOutput(html, options)


### PR DESCRIPTION
Currently `strikethrough` is not enabled for Markdown, but it should be.


## How to test the PR

Format a Markdown string with `~~strikethrough~~` included, and check that it renders properly.
