### PR TITLE
fix edge cases in the regex debugger

### DIFF
--- a/.meta/122.md
+++ b/.meta/122.md
@@ -1,0 +1,5 @@
+## fix edge cases in the regex debugger
+
+By [@recurser](https://github.com/recurser)
+
+Created 2022-01-09 09:31

--- a/locales/en/domain-convert-outputs-regexOutput.json
+++ b/locales/en/domain-convert-outputs-regexOutput.json
@@ -1,17 +1,22 @@
 {
   "alert_invalid_input": "The regular expression is invalid",
-  "alert_match_label": {
-    "one": "Match {{number}} has {{count}} matching group 👇",
-    "other": "Match {{number}} has {{count}} matching groups 👇"
+  "alert_multiple_matches": {
+    "0": "Match {{number}} has no captured groups 👇",
+    "one": "Match {{number}} has {{count}} captured group 👇",
+    "other": "Match {{number}} has {{count}} captured groups 👇"
   },
   "alert_no_input": "Enter a test string to debug your regular expression 👆",
   "alert_no_matches": "There are no matches",
-  "alert_num_groups": {
-    "one": "There is {{count}} matching group 👇",
-    "other": "There are {{count}} matching groups 👇"
+  "alert_single_match": {
+    "0": "There is a match, with no captured groups",
+    "one": "There is a match, with {{count}} captured group 👇",
+    "other": "There is a match, with {{count}} captured groups 👇"
   },
   "group_label": "Group {{number}}:",
-  "match_label": "Match {{number}}:",
+  "match_label": {
+    "one": "Match:",
+    "other": "Match {{number}}:"
+  },
   "test_string_header": "Enter a test string:",
   "test_string_placeholder": "Enter a string to test your regular expression against..."
 }

--- a/src/components/domain/convert/outputs/RegexOutput.tsx
+++ b/src/components/domain/convert/outputs/RegexOutput.tsx
@@ -21,10 +21,15 @@ export const RegexOutput = forwardRef<HTMLTextAreaElement, OutputProps>(
           input.match(/^\/(.*)\/([igm]+)?$/) || []
         const regex = new RegExp(regexStr.replace(/\n/, ''), modifiers)
         // The matchAll() method throws an error if the 'g' modifier has not been provided.
-        if (modifiers.includes('g')) {
+        if (modifiers?.includes('g')) {
           return [...testString.matchAll(regex)]
         } else {
-          return [testString.match(regex) || []]
+          const result = testString.match(regex)
+          if (result && result.length > 0) {
+            return [result]
+          } else {
+            return []
+          }
         }
       } catch (err) {
         return undefined
@@ -65,7 +70,6 @@ export const RegexOutput = forwardRef<HTMLTextAreaElement, OutputProps>(
             {matches.map((match, matchIndex) => {
               const [whole, ...groups] = match
               const matchKey = `regexMatch-${matchIndex}`
-              const isSingleMatch = matches.length === 1
 
               return (
                 <>
@@ -73,20 +77,23 @@ export const RegexOutput = forwardRef<HTMLTextAreaElement, OutputProps>(
                     intent="success"
                     marginBottom={majorScale(1)}
                     title={
-                      isSingleMatch
-                        ? t('alert_num_groups', { count: groups.length })
-                        : t('alert_match_label', {
+                      matches.length === 1
+                        ? t('alert_single_match', { count: groups.length })
+                        : t('alert_multiple_matches', {
                             count: groups.length,
                             number: matchIndex + 1,
                           })
                     }
                   />
 
-                  {!isSingleMatch && (
+                  {
                     <Label
                       htmlFor={matchKey}
                       key={matchKey}
-                      label={t('match_label', { number: matchIndex + 1 })}
+                      label={t('match_label', {
+                        count: matches.length,
+                        number: matchIndex + 1,
+                      })}
                     >
                       <TextInput
                         id={matchKey}
@@ -95,7 +102,7 @@ export const RegexOutput = forwardRef<HTMLTextAreaElement, OutputProps>(
                         width="100%"
                       />
                     </Label>
-                  )}
+                  }
 
                   {groups.map((group, groupIndex) => {
                     const groupKey = `regexMatch-${matchIndex}-${groupIndex}`


### PR DESCRIPTION
## How to test the PR

Test regexes without any modifiers (eg. `/asdf/`) - they were reporting as invalid before because of a check against a null string throwing an error.
