### PR TITLE
Remember which converters were used most recently

### DIFF
--- a/.meta/123.md
+++ b/.meta/123.md
@@ -1,0 +1,5 @@
+## remember which converters were used most recently
+
+By [@recurser](https://github.com/recurser)
+
+Created 2022-01-09 09:56

--- a/src/components/domain/convert/ConverterSelector.tsx
+++ b/src/components/domain/convert/ConverterSelector.tsx
@@ -5,23 +5,19 @@ import {
   SelectMenu,
   SelectMenuItem,
 } from 'evergreen-ui'
-import { isEmpty } from 'lodash'
+import { isEmpty, minBy } from 'lodash'
 import useTranslation from 'next-translate/useTranslation'
-import {
-  createRef,
-  Dispatch,
-  SetStateAction,
-  useEffect,
-  useMemo,
-  useState,
-} from 'react'
+import { Dispatch, SetStateAction, useEffect, useMemo, useState } from 'react'
 
 import { LayoutColumn } from '@components/domain/convert/LayoutColumn'
-import { useConverterContext } from '@contexts/ConverterContext'
+import {
+  recentConverterIds,
+  useConverterContext,
+} from '@contexts/ConverterContext'
 import { useInputContext } from '@contexts/InputContext'
 import { NullConverter } from '@lib/converters'
 import * as converterModule from '@lib/converters'
-import { selectConverter } from '@services/Converter'
+import { converterCandidates } from '@services/Converter'
 
 interface Props {
   setFocusOutput: Dispatch<SetStateAction<boolean>>
@@ -35,10 +31,6 @@ export const ConverterSelector = ({ setFocusOutput }: Props) => {
   const { inputString } = useInputContext()
   const [selected, setSelected] = useState<string | undefined>()
 
-  // A bit of a hack due to limitations with <SelectMenu />, but we use this
-  // to be able to trigger a click and open the menu programatically.
-  const buttonRef = createRef<HTMLButtonElement>()
-
   useEffect(() => {
     async function fetchData() {
       if (isEmpty(inputString)) {
@@ -46,14 +38,24 @@ export const ConverterSelector = ({ setFocusOutput }: Props) => {
       }
 
       if (!selected) {
-        const winner = await selectConverter(inputString)
-        if (winner) {
-          setSelected(winner.id)
+        const candidates = await converterCandidates(inputString)
+
+        if (candidates.length > 0) {
+          const recentIds = recentConverterIds()
+          const recent =
+            // We're looking for the recentIds with the lowest array index (ie the most recent).
+            minBy(
+              candidates,
+              (candidate) =>
+                recentIds.includes(candidate.id) &&
+                recentIds.indexOf(candidate.id),
+            ) || candidates[0]
+          setSelected(recent.id)
         }
       }
     }
     fetchData()
-  }, [buttonRef, inputString, selected, setSelected])
+  }, [inputString, selected, setSelected])
 
   // Set the converter based on the selected value. Ideally we could use the
   // converter directly in <SelectMenu />, but unfortunately it only supports
@@ -93,7 +95,6 @@ export const ConverterSelector = ({ setFocusOutput }: Props) => {
           <Button
             flex={1}
             iconAfter={selected ? ChevronRightIcon : undefined}
-            ref={buttonRef}
             tabIndex={2}
           >
             {selected

--- a/src/components/domain/convert/ConverterSelector.tsx
+++ b/src/components/domain/convert/ConverterSelector.tsx
@@ -17,25 +17,21 @@ import {
 } from 'react'
 
 import { LayoutColumn } from '@components/domain/convert/LayoutColumn'
+import { useConverterContext } from '@contexts/ConverterContext'
 import { useInputContext } from '@contexts/InputContext'
-import { Converter, NullConverter } from '@lib/converters'
+import { NullConverter } from '@lib/converters'
 import * as converterModule from '@lib/converters'
 import { selectConverter } from '@services/Converter'
 
 interface Props {
-  converter: Converter
   setFocusOutput: Dispatch<SetStateAction<boolean>>
-  setConverter: Dispatch<SetStateAction<Converter>>
 }
 
 const converters = Object.values(converterModule)
 
-export const ConverterSelector = ({
-  converter,
-  setFocusOutput,
-  setConverter,
-}: Props) => {
+export const ConverterSelector = ({ setFocusOutput }: Props) => {
   const { t } = useTranslation('domain-convert-converterSelector')
+  const { converter, setConverter } = useConverterContext()
   const { inputString } = useInputContext()
   const [selected, setSelected] = useState<string | undefined>()
 

--- a/src/components/domain/convert/ConverterSelector.tsx
+++ b/src/components/domain/convert/ConverterSelector.tsx
@@ -23,13 +23,18 @@ import * as converterModule from '@lib/converters'
 import { selectConverter } from '@services/Converter'
 
 interface Props {
+  converter: Converter
   setFocusOutput: Dispatch<SetStateAction<boolean>>
   setConverter: Dispatch<SetStateAction<Converter>>
 }
 
 const converters = Object.values(converterModule)
 
-export const ConverterSelector = ({ setFocusOutput, setConverter }: Props) => {
+export const ConverterSelector = ({
+  converter,
+  setFocusOutput,
+  setConverter,
+}: Props) => {
   const { t } = useTranslation('domain-convert-converterSelector')
   const { inputString } = useInputContext()
   const [selected, setSelected] = useState<string | undefined>()
@@ -58,9 +63,12 @@ export const ConverterSelector = ({ setFocusOutput, setConverter }: Props) => {
   // converter directly in <SelectMenu />, but unfortunately it only supports
   // string and number values.
   useEffect(() => {
-    const cnvt = converters.find((converter) => converter.id === selected)
-    setConverter(cnvt || NullConverter)
-  }, [setConverter, selected])
+    const cnvt =
+      converters.find((candidate) => candidate.id === selected) || NullConverter
+    if (converter.id !== cnvt.id) {
+      setConverter(cnvt || NullConverter)
+    }
+  }, [converter.id, setConverter, selected])
 
   const options = useMemo(() => {
     return converters

--- a/src/components/domain/convert/OutputForm.tsx
+++ b/src/components/domain/convert/OutputForm.tsx
@@ -13,23 +13,20 @@ import { LayoutColumn } from '@components/domain/convert/LayoutColumn'
 import { OutputError } from '@components/domain/convert/OutputError'
 import * as outputs from '@components/domain/convert/outputs'
 import type { OutputName } from '@components/domain/convert/outputs'
+import { useConverterContext } from '@contexts/ConverterContext'
 import { useConverterOptionsContext } from '@contexts/ConverterOptionsContext'
 import { useInputContext } from '@contexts/InputContext'
-import { Converter, NullConverter } from '@lib/converters'
+import { NullConverter } from '@lib/converters'
 import { useAnalytics } from '@services/Analytics'
 
 interface Props {
-  converter: Converter
   focusOutput: boolean
   setFocusOutput: Dispatch<SetStateAction<boolean>>
 }
-export const OutputForm = ({
-  converter,
-  focusOutput,
-  setFocusOutput,
-}: Props) => {
+export const OutputForm = ({ focusOutput, setFocusOutput }: Props) => {
   const { t } = useTranslation('domain-convert-outputForm')
   const analytics = useAnalytics()
+  const { converter } = useConverterContext()
   const { inputString } = useInputContext()
   const textareaRef = createRef<HTMLTextAreaElement>()
 

--- a/src/components/domain/convert/OutputForm.tsx
+++ b/src/components/domain/convert/OutputForm.tsx
@@ -17,7 +17,6 @@ import { useConverterContext } from '@contexts/ConverterContext'
 import { useConverterOptionsContext } from '@contexts/ConverterOptionsContext'
 import { useInputContext } from '@contexts/InputContext'
 import { NullConverter } from '@lib/converters'
-import { useAnalytics } from '@services/Analytics'
 
 interface Props {
   focusOutput: boolean
@@ -25,7 +24,6 @@ interface Props {
 }
 export const OutputForm = ({ focusOutput, setFocusOutput }: Props) => {
   const { t } = useTranslation('domain-convert-outputForm')
-  const analytics = useAnalytics()
   const { converter } = useConverterContext()
   const { inputString } = useInputContext()
   const textareaRef = createRef<HTMLTextAreaElement>()
@@ -35,17 +33,8 @@ export const OutputForm = ({ focusOutput, setFocusOutput }: Props) => {
     if (focusOutput) {
       textareaRef.current?.focus()
       setFocusOutput(false)
-
-      if (converter) {
-        // Track which converter has been selected, to find out which are useful.
-        analytics('Convert', {
-          props: {
-            converter: converter.id,
-          },
-        })
-      }
     }
-  }, [analytics, converter, focusOutput, setFocusOutput, textareaRef])
+  }, [focusOutput, setFocusOutput, textareaRef])
 
   // Use a dynamic output component based on the converter's 'output' string.
   const OutputElement = useMemo(() => {

--- a/src/components/layout/Application.tsx
+++ b/src/components/layout/Application.tsx
@@ -3,6 +3,7 @@ import { PropsWithChildren, ReactElement } from 'react'
 
 import { Footer } from '@components/layout/Footer'
 import { Header } from '@components/layout/Header'
+import { ConverterContext } from '@contexts/ConverterContext'
 import { ConverterOptionsContext } from '@contexts/ConverterOptionsContext'
 import { InputContext } from '@contexts/InputContext'
 import { AnalyticsProvider } from '@services/Analytics'
@@ -16,25 +17,27 @@ export const Application = ({
   maxWidth,
 }: PropsWithChildren<Props>): ReactElement => (
   <AnalyticsProvider>
-    <ConverterOptionsContext>
-      <InputContext>
-        <Pane
-          display="flex"
-          flexDirection="column"
-          justifyContent="center"
-          marginLeft="auto"
-          marginRight="auto"
-          maxWidth={maxWidth}
-          paddingTop={majorScale(3)}
-        >
-          <Header />
+    <ConverterContext>
+      <ConverterOptionsContext>
+        <InputContext>
+          <Pane
+            display="flex"
+            flexDirection="column"
+            justifyContent="center"
+            marginLeft="auto"
+            marginRight="auto"
+            maxWidth={maxWidth}
+            paddingTop={majorScale(3)}
+          >
+            <Header />
 
-          <Pane>{children}</Pane>
+            <Pane>{children}</Pane>
 
-          <Footer />
-        </Pane>
-      </InputContext>
-    </ConverterOptionsContext>
+            <Footer />
+          </Pane>
+        </InputContext>
+      </ConverterOptionsContext>
+    </ConverterContext>
   </AnalyticsProvider>
 )
 

--- a/src/components/pages/Convert.tsx
+++ b/src/components/pages/Convert.tsx
@@ -9,13 +9,11 @@ import {
   ConverterSelector,
 } from '@components/domain/convert'
 import { Card } from '@components/layout/Card'
-import { Converter, NullConverter } from '@lib/converters'
 import { useBreakpoints } from '@services/Responsive'
 
 export const Convert = () => {
   const { t } = useTranslation('pages-convert')
   const { isMobile } = useBreakpoints()
-  const [converter, setConverter] = useState<Converter>(NullConverter)
   const [focusOutput, setFocusOutput] = useState<boolean>(false)
 
   return (
@@ -40,15 +38,10 @@ export const Convert = () => {
             maxWidth={majorScale(20)}
             minWidth={0}
           >
-            <ConverterSelector
-              converter={converter}
-              setConverter={setConverter}
-              setFocusOutput={setFocusOutput}
-            />
+            <ConverterSelector setFocusOutput={setFocusOutput} />
           </Pane>
 
           <OutputForm
-            converter={converter || NullConverter}
             focusOutput={focusOutput}
             setFocusOutput={setFocusOutput}
           />

--- a/src/components/pages/Convert.tsx
+++ b/src/components/pages/Convert.tsx
@@ -41,6 +41,7 @@ export const Convert = () => {
             minWidth={0}
           >
             <ConverterSelector
+              converter={converter}
               setConverter={setConverter}
               setFocusOutput={setFocusOutput}
             />

--- a/src/contexts/ConverterContext.tsx
+++ b/src/contexts/ConverterContext.tsx
@@ -17,6 +17,10 @@ interface Props {
 
 const localStorageKey = 'string.is:RecentConverters'
 
+// Returns an array of recently-used converter IDs.
+export const recentConverterIds = () =>
+  JSON.parse(window.localStorage.getItem(localStorageKey) || '[]')
+
 const Context = createContext<Props>({
   converter: NullConverter,
   setConverter: (_: Converter) => undefined,
@@ -38,9 +42,7 @@ export const useConverterContext = (): Props => {
       })
 
       // Remember which converters were used most recently, so we can improve auto-selection.
-      let recent = JSON.parse(
-        window.localStorage.getItem(localStorageKey) || '[]',
-      )
+      let recent = recentConverterIds()
       recent = recent.filter((converterId: string) => converterId != cnvt.id)
       recent.unshift(cnvt.id)
       window.localStorage.setItem(localStorageKey, JSON.stringify(recent))

--- a/src/contexts/ConverterContext.tsx
+++ b/src/contexts/ConverterContext.tsx
@@ -1,0 +1,31 @@
+import {
+  createContext,
+  Dispatch,
+  PropsWithChildren,
+  ReactElement,
+  useContext,
+  useState,
+} from 'react'
+
+import { Converter, NullConverter } from '@lib/converters'
+
+interface Props {
+  converter: Converter
+  setConverter: Dispatch<Converter>
+}
+
+const Context = createContext<Props>({
+  converter: NullConverter,
+  setConverter: (_: Converter) => undefined,
+})
+
+export const useConverterContext = (): Props => useContext(Context)
+
+export const ConverterContext = ({
+  children,
+}: PropsWithChildren<Record<string, unknown>>): ReactElement => {
+  const [converter, setConverter] = useState<Converter>(NullConverter)
+
+  const value = { converter, setConverter }
+  return <Context.Provider value={value}>{children}</Context.Provider>
+}

--- a/src/contexts/ConverterContext.tsx
+++ b/src/contexts/ConverterContext.tsx
@@ -8,6 +8,7 @@ import {
 } from 'react'
 
 import { Converter, NullConverter } from '@lib/converters'
+import { useAnalytics } from '@services/Analytics'
 
 interface Props {
   converter: Converter
@@ -19,7 +20,25 @@ const Context = createContext<Props>({
   setConverter: (_: Converter) => undefined,
 })
 
-export const useConverterContext = (): Props => useContext(Context)
+export const useConverterContext = (): Props => {
+  const { converter, setConverter } = useContext(Context)
+  const analytics = useAnalytics()
+
+  const wrappedSetConverter = (cnvt: Converter) => {
+    setConverter(cnvt)
+
+    if (cnvt.id !== NullConverter.id) {
+      // Track which converter has been selected, to find out which are useful.
+      analytics('Convert', {
+        props: {
+          converter: cnvt.id,
+        },
+      })
+    }
+  }
+
+  return { converter, setConverter: wrappedSetConverter }
+}
 
 export const ConverterContext = ({
   children,

--- a/src/contexts/ConverterContext.tsx
+++ b/src/contexts/ConverterContext.tsx
@@ -15,6 +15,8 @@ interface Props {
   setConverter: Dispatch<Converter>
 }
 
+const localStorageKey = 'string.is:RecentConverters'
+
 const Context = createContext<Props>({
   converter: NullConverter,
   setConverter: (_: Converter) => undefined,
@@ -34,6 +36,14 @@ export const useConverterContext = (): Props => {
           converter: cnvt.id,
         },
       })
+
+      // Remember which converters were used most recently, so we can improve auto-selection.
+      let recent = JSON.parse(
+        window.localStorage.getItem(localStorageKey) || '[]',
+      )
+      recent = recent.filter((converterId: string) => converterId != cnvt.id)
+      recent.unshift(cnvt.id)
+      window.localStorage.setItem(localStorageKey, JSON.stringify(recent))
     }
   }
 

--- a/src/contexts/InputContext.tsx
+++ b/src/contexts/InputContext.tsx
@@ -7,17 +7,17 @@ import {
   useState,
 } from 'react'
 
-interface InputProps {
+interface Props {
   inputString: string
   setInputString: Dispatch<string>
 }
 
-const Context = createContext<InputProps>({
+const Context = createContext<Props>({
   inputString: '',
   setInputString: (_: string) => undefined,
 })
 
-export const useInputContext = (): InputProps => useContext(Context)
+export const useInputContext = (): Props => useContext(Context)
 
 export const InputContext = ({
   children,

--- a/src/services/Converter.ts
+++ b/src/services/Converter.ts
@@ -1,5 +1,5 @@
 import Promise from 'bluebird'
-import { maxBy } from 'lodash'
+import { maxBy, uniqBy } from 'lodash'
 
 import { Converter } from '@lib/converters'
 import { Identity } from '@lib/identities'
@@ -12,9 +12,9 @@ interface Candidate {
 
 const identities = Object.values(untypedIdentities as unknown as Identity[])
 
-export const selectConverter = async (
+export const converterCandidates = async (
   inputString: string,
-): Promise<Converter | undefined> => {
+): Promise<Converter[]> => {
   const candidates = (
     await Promise.all(
       identities.map((identity): Promise<Candidate[]> => {
@@ -36,5 +36,10 @@ export const selectConverter = async (
     )
   ).flat()
 
-  return maxBy(candidates, 'confidence')?.converter
+  const maxConfidence = maxBy(candidates, 'confidence')?.confidence || 0
+  const filtered = candidates
+    .filter((candidate) => candidate.confidence === maxConfidence)
+    .map((candidate) => candidate.converter)
+  const unique = uniqBy(filtered, 'id')
+  return unique
 }


### PR DESCRIPTION
If presented with multiple conversion options at the same confidence level, choose the one that was most recently used.


## How to test the PR

- Paste `{ a: 10 }` - it should auto-select the JSON formatter.
- Manually select the `JSON to CSV` converter.
- Reload the page and paste `{ a: 10 }` again. It should auto-select the JSON `JSON to CSV` converter this time.
