### PR TITLE
add missing unique key to RegexOutput elements

### DIFF
--- a/.meta/134.md
+++ b/.meta/134.md
@@ -1,0 +1,5 @@
+## add missing unique key to RegexOutput elements
+
+By [@recurser](https://github.com/recurser)
+
+Created 2022-01-16 02:43

--- a/src/components/domain/convert/outputs/RegexOutput.tsx
+++ b/src/components/domain/convert/outputs/RegexOutput.tsx
@@ -1,6 +1,6 @@
 import { Alert, majorScale, TextInput } from 'evergreen-ui'
 import useTranslation from 'next-translate/useTranslation'
-import { ChangeEvent, forwardRef, useMemo, useState } from 'react'
+import { ChangeEvent, forwardRef, Fragment, useMemo, useState } from 'react'
 
 import { CodeTextarea, Label } from '@components/forms'
 import { OutputProps } from '@lib/types'
@@ -72,7 +72,7 @@ export const RegexOutput = forwardRef<HTMLTextAreaElement, OutputProps>(
               const matchKey = `regexMatch-${matchIndex}`
 
               return (
-                <>
+                <Fragment key={matchKey}>
                   <Alert
                     intent="success"
                     marginBottom={majorScale(1)}
@@ -121,7 +121,7 @@ export const RegexOutput = forwardRef<HTMLTextAreaElement, OutputProps>(
                       </Label>
                     )
                   })}
-                </>
+                </Fragment>
               )
             })}
           </>


### PR DESCRIPTION

<img width="748" alt="Screen Shot 2022-01-16 at 12 11 51" src="https://user-images.githubusercontent.com/96322/149645860-e3adedaa-ec63-4812-bc1e-89ac892f32ed.png">



## How to test the PR

Enter `/asdf/` and check the console - there should be no React missing key warnings.
