### PR TITLE
fix unwanted exception when identifying YAML

### DIFF
--- a/.meta/136.md
+++ b/.meta/136.md
@@ -1,0 +1,5 @@
+## fix unwanted exception when identifying YAML
+
+By [@recurser](https://github.com/recurser)
+
+Created 2022-01-17 11:11

--- a/src/lib/identities/YamlIdentity.ts
+++ b/src/lib/identities/YamlIdentity.ts
@@ -24,9 +24,11 @@ export const confidence = (data: string) => {
   // Some strings (eg. '[1, 2, 3]') get returned as valid YAML. If something
   // can be parsed as JSON, it is extremely unlikely to also be YAML - the
   // JSON parsing is more likely to be correct.
-  if (jsonInput(data) !== undefined) {
-    return 0
-  }
+  try {
+    if (jsonInput(data) !== undefined) {
+      return 0
+    }
+  } catch(_err) { }
 
   return 100
 }


### PR DESCRIPTION
There is an exception during YAML identification which causers valid YAML not to be identified.

## How to test the PR

Paste valid YAML and check that it gets auto-identified properly.
