### PR TITLE
Remove blank lines from CSV input

### DIFF
--- a/.meta/138.md
+++ b/.meta/138.md
@@ -1,0 +1,5 @@
+## remove blank lines from CSV input
+
+By [@recurser](https://github.com/recurser)
+
+Created 2022-01-17 13:32

--- a/src/lib/inputs/CsvInput.ts
+++ b/src/lib/inputs/CsvInput.ts
@@ -10,7 +10,10 @@ export const input = (data: string): unknown[] | undefined => {
     return undefined
   }
 
-  const { data: obj, errors } = parse(data, defaults)
+  // Replace blank lines, and any final linebreak, since they break the CSV parser.
+  const noBlanks = data.replace(/^\s*[\r\n]/gm, '').replace(/[\r\n]$/gm, '')
+
+  const { data: obj, errors } = parse(noBlanks, defaults)
 
   if (errors.length > 0) {
     throw new Error(errors[0].message)


### PR DESCRIPTION
Blank lines and trailing linebreaks break the CSV parser.

<img width="857" alt="Screen Shot 2022-01-17 at 22 56 13" src="https://user-images.githubusercontent.com/96322/149781629-016aa73a-997b-4e6f-9214-2f73d25af771.png">
