### PR TITLE
add a Windows alternative

### DIFF
--- a/.meta/157.md
+++ b/.meta/157.md
@@ -1,0 +1,5 @@
+## add Windows alternative
+
+By [@recurser](https://github.com/recurser)
+
+Created 2022-01-24 23:40

--- a/locales/en/pages-about.json
+++ b/locales/en/pages-about.json
@@ -3,6 +3,7 @@
   "heading_alternatives": "Alternatives",
   "li_acknowledgement_is_html": "HTML code detection was inspired by <0>is-html</0>.",
   "li_alternative_cyber_chef": "<0>CyberChef</0> by the UK\u2019s <1>GCHQ</1> provides an exhaustive set of conversion and crypto tools, and works both online and offline.",
+  "li_alternative_dev_toys": "<0>DevToys</0> by <1>Etienne Baudoux</1> is an open-source Windows desktop tool which looks very good, although I haven't tried it.",
   "li_alternative_dev_utils": "<0>DevUtils</0> by <1>Tony Dinh</1> is a great open-source MacOS desktop tool.",
   "li_goal_client_side": "It should do all conversions on the client-side.",
   "li_goal_intelligent": "It should try to detect the format of the input, and intelligently choose output options.",

--- a/src/components/pages/About.tsx
+++ b/src/components/pages/About.tsx
@@ -83,6 +83,24 @@ export const About = () => {
             <Trans
               components={[
                 <Link
+                  href="https://devtoys.app/"
+                  key="li_alternative_dev_toys_1"
+                  target="_blank"
+                />,
+                <Link
+                  href="https://github.com/veler"
+                  key="li_alternative_dev_toys_2"
+                  target="_blank"
+                />,
+              ]}
+              i18nKey="pages-about:li_alternative_dev_toys"
+            />
+          </ListItem>
+
+          <ListItem>
+            <Trans
+              components={[
+                <Link
                   href="https://gchq.github.io/CyberChef/"
                   key="li_alternative_cyber_chef_1"
                   target="_blank"


### PR DESCRIPTION
Add https://devtoys.app/ to the `/about` page as an alternative.