### PR TITLE
make the chevron icons consistent with layout on mobile

### DIFF
--- a/.meta/166.md
+++ b/.meta/166.md
@@ -1,0 +1,5 @@
+## make the chevron icons consistent with layout on mobile
+
+By [@recurser](https://github.com/recurser)
+
+Created 2022-01-31 00:00

--- a/src/components/domain/convert/ConverterSelector.tsx
+++ b/src/components/domain/convert/ConverterSelector.tsx
@@ -1,12 +1,15 @@
 import {
   Button,
+  ChevronDownIcon,
   ChevronRightIcon,
   Pane,
   SelectMenu,
   SelectMenuItem,
+  majorScale,
 } from 'evergreen-ui'
 import { Dispatch, SetStateAction, useEffect, useMemo, useState } from 'react'
 import { isEmpty, minBy } from 'lodash'
+import { useBreakpoints } from '@services/Responsive'
 import useTranslation from 'next-translate/useTranslation'
 
 import * as converterModule from '@lib/converters'
@@ -25,6 +28,7 @@ const converters = Object.values(converterModule)
 
 export const ConverterSelector = ({ setFocusOutput }: Props) => {
   const { t } = useTranslation('domain-convert-converterSelector')
+  const { isMobile } = useBreakpoints()
   const {
     clearConverter,
     converter,
@@ -93,6 +97,15 @@ export const ConverterSelector = ({ setFocusOutput }: Props) => {
     setSelected(value as string)
   }
 
+  const icon = useMemo(() => {
+    if (selected && isMobile) {
+      return ChevronDownIcon
+    } else if (selected) {
+      return ChevronRightIcon
+    }
+    return undefined
+  }, [isMobile, selected])
+
   return (
     <SelectMenu
       closeOnSelect={true}
@@ -105,7 +118,8 @@ export const ConverterSelector = ({ setFocusOutput }: Props) => {
       <Pane display="flex">
         <Button
           flex={1}
-          iconAfter={selected ? ChevronRightIcon : undefined}
+          iconAfter={icon}
+          maxWidth={majorScale(20)}
           tabIndex={2}
         >
           {selected

--- a/src/components/domain/convert/UseAsInputButton.tsx
+++ b/src/components/domain/convert/UseAsInputButton.tsx
@@ -1,12 +1,20 @@
-import { Button, ChevronLeftIcon, Pane, majorScale } from 'evergreen-ui'
+import {
+  Button,
+  ChevronLeftIcon,
+  ChevronUpIcon,
+  Pane,
+  majorScale,
+} from 'evergreen-ui'
 import { useEffect, useState } from 'react'
 import { isEmpty } from 'lodash'
 import useTranslation from 'next-translate/useTranslation'
 
+import { useBreakpoints } from '@services/Responsive'
 import { useConverterContext } from '@contexts/ConverterContext'
 
 export const UseAsInputButton = () => {
   const { t } = useTranslation('domain-convert-useAsInputButton')
+  const { isMobile } = useBreakpoints()
   const [disabled, setDisabled] = useState(true)
   const { outputString, setUseOutput } = useConverterContext()
 
@@ -24,7 +32,8 @@ export const UseAsInputButton = () => {
       <Button
         disabled={disabled}
         flex={1}
-        iconBefore={ChevronLeftIcon}
+        iconBefore={isMobile ? ChevronUpIcon : ChevronLeftIcon}
+        maxWidth={majorScale(20)}
         onClick={onClick}
       >
         {t('button_label')}

--- a/src/components/pages/Convert.tsx
+++ b/src/components/pages/Convert.tsx
@@ -35,10 +35,11 @@ export const Convert = () => {
           <InputForm />
 
           <Pane
+            alignItems="center"
             display="flex"
             flexDirection="column"
             flexGrow={1}
-            maxWidth={majorScale(20)}
+            maxWidth={isMobile ? undefined : majorScale(20)}
             minWidth={0}
           >
             <LayoutColumn>


### PR DESCRIPTION
Makes the chevron icons point up-and-down instead of left-to-right on mobile, to match the screen layout.

## How to test the PR

- Switch between mobile and desktop view and check that the icons are appropriate.