### PR TITLE
Handle parsing of times when UTC is explicitly specified

### DIFF
--- a/.meta/1076.md
+++ b/.meta/1076.md
@@ -1,0 +1,5 @@
+## Handle parsing of times when UTC is explicitly specified
+
+By [@recurser](https://github.com/recurser)
+
+Created 2023-08-02 04:26

--- a/src/components/domain/convert/OutputForm.tsx
+++ b/src/components/domain/convert/OutputForm.tsx
@@ -64,7 +64,10 @@ export const OutputForm = ({ focusOutput, setFocusOutput }: Props) => {
       try {
         const res = converter.operation(inputString, options)
 
-        if (typeof res === 'object' && typeof (res as Promise<string>).then === 'function') {
+        if (
+          typeof res === 'object' &&
+          typeof (res as Promise<string>).then === 'function'
+        ) {
           setOutput(await res)
         } else {
           setOutput(res as string)

--- a/src/lib/converters/index.ts
+++ b/src/lib/converters/index.ts
@@ -66,7 +66,10 @@ export interface Converter {
    * An operation on the input string, with the given
    * options, that returns a converted output.
    */
-  operation: (input: string, options?: ConverterOptions) => string | Promise<string>
+  operation: (
+    input: string,
+    options?: ConverterOptions,
+  ) => string | Promise<string>
 
   /**
    * A string which uniquely identifies the output component used by

--- a/src/lib/inputs/TimestampInput.ts
+++ b/src/lib/inputs/TimestampInput.ts
@@ -47,13 +47,17 @@ export const input = (data: string): string | undefined => {
   } else {
     // If the user has provided a timezone (eg. 3pm PST), interpret the
     // parsed date in terms of that timezone.
-    const offset =
+    let offset =
       timezone &&
       timezones.find((tz) => tz.shortcode === timezone?.toUpperCase())?.offset
 
+    if (typeof offset === 'string') {
+      offset = parseInt(offset, 10)
+    }
+
     let result
-    if (offset) {
-      result = parse(final, { timezone: offset * 60 })
+    if (offset !== undefined) {
+      result = parse(final, { timezone: (offset as number) * 60 })
     } else {
       result = parse(final)
     }

--- a/src/lib/inputs/__tests__/TimestampInput.test.ts
+++ b/src/lib/inputs/__tests__/TimestampInput.test.ts
@@ -14,6 +14,12 @@ describe('inputs', () => {
         expect(input(data)).toEqual(expected)
       })
 
+      it('parses explicitly UTC time strings', () => {
+        const data = '2020-01-01 12:13 UTC'
+        const expected = '1577880780000'
+        expect(input(data)).toEqual(expected)
+      })
+
       it('parses keywords that trigger the current time', () => {
         const spy = jest
           .spyOn(global.Date, 'now')


### PR DESCRIPTION
Replace this with a detailed explanation of the change


## How to test the PR

`2023-08-01 22:35:10 UTC in AEST`


## Checklist

- [x] New functionality has tests.
- [ ] README has been updated (if necessary).
- [ ] New environment variables have been added to `.env.example` (if necessary).