### PR TITLE
feat: support deployment under a sub-path

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -4,3 +4,4 @@ export GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 export NEXT_PUBLIC_ANALYTICS_DOMAIN=string.test
 export NEXT_PUBLIC_ANALYTICS_ENABLED=false
 export NODENV_VERSION=20.6.1
+export NEXT_PUBLIC_BASE_PATH=/string # supply this if you are deploying to a sub-path of your domain like https://tools.example.com/string

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,10 @@ WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
+# Set environment variables
+ARG NEXT_PUBLIC_BASE_PATH
+ENV NEXT_PUBLIC_BASE_PATH=$NEXT_PUBLIC_BASE_PATH
+
 ENV NEXT_TELEMETRY_DISABLED 1
 ENV OUTPUT_STANDALONE 1
 RUN yarn build

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
 # Set environment variables
-ARG NEXT_PUBLIC_BASE_PATH
+ARG NEXT_PUBLIC_BASE_PATH=""
 ENV NEXT_PUBLIC_BASE_PATH=$NEXT_PUBLIC_BASE_PATH
 
 ENV NEXT_TELEMETRY_DISABLED 1

--- a/README.md
+++ b/README.md
@@ -131,7 +131,25 @@ The quickest way to deploy string.is is to use the [Vercel Platform](https://ver
 
 Unfortunately string.is doesn't currently support static builds via `next export` (which would allow hosting on eg. S3), because the `i18n` feature it uses is not currently supported for static builds.
 
-If you're deploying string.is under a sub-path of a domain, you'll need to set the `NEXT_PUBLIC_BASE_PATH` environment variable to the sub-path. For example, if you're deploying to `https://tools.example.com/string-is`, you'll need to set `NEXT_PUBLIC_BASE_PATH` to `/string-is`.
+### Deploy string.is under a sub-path of a domain
+
+Set the `NEXT_PUBLIC_BASE_PATH` environment variable to the sub-path, then build the project before deploying. This value must be set at build time and cannot be changed without re-building as the value is inlined in the client-side bundles.
+
+For example, if you're deploying to `https://tools.example.com/string-is`, you'll need to set `NEXT_PUBLIC_BASE_PATH` to `/string-is`. You don't need to set this variable if you're deploying to the root of a domain.
+
+Build and run with Docker:
+
+```bash
+docker build -t string-is --build-arg NEXT_PUBLIC_BASE_PATH="/string-is" .
+docker run -p 3000:3000 string-is
+```
+
+Or build and run with `docker-compose`:
+
+```bash
+export NEXT_PUBLIC_BASE_PATH="/string-is"
+docker-compose up --build
+```
 
 ## Localization
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ The quickest way to deploy string.is is to use the [Vercel Platform](https://ver
 
 Unfortunately string.is doesn't currently support static builds via `next export` (which would allow hosting on eg. S3), because the `i18n` feature it uses is not currently supported for static builds.
 
+If you're deploying string.is under a sub-path of a domain, you'll need to set the `NEXT_PUBLIC_BASE_PATH` environment variable to the sub-path. For example, if you're deploying to `https://tools.example.com/string-is`, you'll need to set `NEXT_PUBLIC_BASE_PATH` to `/string-is`.
 
 ## Localization
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     build:
       context: .
       args:
-        - NEXT_PUBLIC_BASE_PATH: ${NEXT_PUBLIC_BASE_PATH}
+        NEXT_PUBLIC_BASE_PATH: ${NEXT_PUBLIC_BASE_PATH:-}
     ports:
       - '3000:3000'
     image: string-is

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,10 @@ version: '3.3'
 
 services:
   string-is:
-    build: .
+    build:
+      context: .
+      args:
+        - NEXT_PUBLIC_BASE_PATH: ${NEXT_PUBLIC_BASE_PATH}
     ports:
       - '3000:3000'
     image: string-is

--- a/next.config.js
+++ b/next.config.js
@@ -109,4 +109,8 @@ module.exports = nextTranslate({
 
     return config
   },
+  // To deploy a Next.js application under a sub-path of a domain you can use the basePath config option.
+  // See https://nextjs.org/docs/app/api-reference/next-config-js/basePath
+  // Note: basePath must be set at build time and cannot be changed without re-building as the value is inlined in the client-side bundles.
+  basePath: process.env.NEXT_PUBLIC_BASE_PATH || '',
 })


### PR DESCRIPTION
This PR adds an environment variable `NEXT_PUBLIC_BASE_PATH` to provide support for deployment under a sub-path.  
For example, if you're deploying to https://tools.example.com/string-is, you'll need to set `NEXT_PUBLIC_BASE_PATH` to `/string-is`.

## Checklist

- [ ] New functionality has tests.
- [x] README has been updated (if necessary).
- [x] New environment variables have been added to `.env.example` (if necessary).