### PR TITLE
feat: Sort Keys no longer sorts arrays

### DIFF
--- a/src/lib/utilities/String.ts
+++ b/src/lib/utilities/String.ts
@@ -1,6 +1,7 @@
 import { camelCase, fromPairs, isArray, isObject, kebabCase, map } from 'lodash'
 
 import type { Obj } from '@lib/types'
+
 /**
  * Converts a hyphenated converter slug to a camel-cased ID identifying
  * the converter module.
@@ -33,18 +34,19 @@ export const hyphenateConverterId = (converterId: string): string => {
 }
 
 /**
- * Sorts the keys of an object recursively, preserving array order.
+ * Sorts the keys of a JSON object recursively, preserving array order.
+ * This function specifically handles JSON objects (not arrays or primitives).
  * 
- * @param obj - The object to sort
- * @returns A new object with sorted keys
+ * @param jsonObj - The JSON object to sort
+ * @returns A new JSON object with sorted keys
  */
-const sortObjectKeys = (obj: Record<string, unknown>): Record<string, unknown> => {
-  const sortedKeys = Object.keys(obj).sort()
+const sortJsonObjectKeys = (jsonObj: Record<string, unknown>): Record<string, unknown> => {
+  const sortedKeys = Object.keys(jsonObj).sort()
   return fromPairs(
     map(sortedKeys, (key: string) => {
-      const value = obj[key]
+      const value = jsonObj[key]
       if (isObject(value) && !isArray(value)) {
-        return [key, sortObjectKeys(value as Record<string, unknown>)]
+        return [key, sortJsonObjectKeys(value as Record<string, unknown>)]
       }
       return [key, value]
     }),
@@ -52,28 +54,28 @@ const sortObjectKeys = (obj: Record<string, unknown>): Record<string, unknown> =
 }
 
 /**
- * Sorts the keys of an object or array recursively.
+ * Sorts the keys of a JSON object or array recursively.
  * For arrays, only sorts keys within array elements, preserving array order.
  * For objects, sorts all keys recursively.
  *
- * @param object - The object whose keys we will sort.
- * @returns the object with sorted keys.
+ * @param jsonData - The JSON data whose keys we will sort.
+ * @returns the JSON data with sorted keys.
  */
-export const sortByKeys = (object: Obj): Obj => {
-  if (object === null || typeof object !== 'object') {
-    return object
+export const sortByKeys = (jsonData: Obj): Obj => {
+  if (jsonData === null || typeof jsonData !== 'object') {
+    return jsonData
   }
 
-  if (isArray(object)) {
-    return (object as unknown[]).map((entry: unknown) => {
+  if (isArray(jsonData)) {
+    return (jsonData as unknown[]).map((entry: unknown) => {
       if (isObject(entry) && !isArray(entry)) {
-        return sortObjectKeys(entry as Record<string, unknown>)
+        return sortJsonObjectKeys(entry as Record<string, unknown>)
       }
       return entry
     })
   }
 
-  return sortObjectKeys(object as Record<string, unknown>)
+  return sortJsonObjectKeys(jsonData as Record<string, unknown>)
 }
 
 /**

--- a/src/lib/utilities/String.ts
+++ b/src/lib/utilities/String.ts
@@ -1,8 +1,6 @@
 import { camelCase, fromPairs, isArray, isObject, kebabCase, map } from 'lodash'
 
 import type { Obj } from '@lib/types'
-import { isArray as isArrayUtil, isObject as isObjectUtil } from '@lib/utilities/Type'
-
 /**
  * Converts a hyphenated converter slug to a camel-cased ID identifying
  * the converter module.
@@ -45,7 +43,7 @@ const sortObjectKeys = (obj: Record<string, unknown>): Record<string, unknown> =
   return fromPairs(
     map(sortedKeys, (key: string) => {
       const value = obj[key]
-      if (isObjectUtil(value) && !isArrayUtil(value)) {
+      if (isObject(value) && !isArray(value)) {
         return [key, sortObjectKeys(value as Record<string, unknown>)]
       }
       return [key, value]
@@ -66,9 +64,9 @@ export const sortByKeys = (object: Obj): Obj => {
     return object
   }
 
-  if (isArrayUtil(object)) {
+  if (isArray(object)) {
     return (object as unknown[]).map((entry: unknown) => {
-      if (isObjectUtil(entry) && !isArrayUtil(entry)) {
+      if (isObject(entry) && !isArray(entry)) {
         return sortObjectKeys(entry as Record<string, unknown>)
       }
       return entry

--- a/src/lib/utilities/__tests__/String.test.ts
+++ b/src/lib/utilities/__tests__/String.test.ts
@@ -50,9 +50,74 @@ describe('utilities', () => {
           { name: 'Bob', age: 28 } // eslint-disable-line sort-keys
         ]
         const expected = [
-          { age: 30, name: 'Charlie' }, // eslint-disable-line sort-keys
-          { age: 25, name: 'Alice' }, // eslint-disable-line sort-keys
-          { age: 28, name: 'Bob' }, // eslint-disable-line sort-keys
+          { age: 30, name: 'Charlie' },
+          { age: 25, name: 'Alice' },
+          { age: 28, name: 'Bob' }
+        ]
+        expect(sortByKeys(input)).toEqual(expected)
+      })
+
+      it('handles nested objects within arrays', () => {
+        const input = [
+          { 
+            name: 'Charlie',
+            details: { // eslint-disable-line sort-keys
+              role: 'Developer',
+              team: 'Frontend'
+            }
+          }
+        ]
+        const expected = [
+          { 
+            details: { 
+              role: 'Developer',
+              team: 'Frontend'
+            },
+            name: 'Charlie'
+          }
+        ]
+        expect(sortByKeys(input)).toEqual(expected)
+      })
+
+      it('preserves primitive values in arrays', () => {
+        const input = [1, 'two', true, null]
+        expect(sortByKeys(input)).toEqual(input)
+      })
+
+      it('handles empty objects and arrays', () => {
+        const input = { emptyArray: [], emptyObject: {} }
+        const expected = { emptyArray: [], emptyObject: {} }
+        expect(sortByKeys(input)).toEqual(expected)
+      })
+
+      it('preserves null and undefined values', () => {
+        const input = { 
+          a: null,
+          b: undefined,
+          c: { d: null }
+        }
+        const expected = { 
+          a: null,
+          b: undefined,
+          c: { d: null }
+        }
+        expect(sortByKeys(input)).toEqual(expected)
+      })
+
+      it('handles mixed arrays of objects and primitives', () => {
+        const input = [
+          { name: 'Charlie' },
+          42,
+          { age: 30 },
+          'string',
+          null
+        ]
+        const expected = [
+          { name: 'Charlie' },
+          42,
+          { age: 30 },
+          'string',
+          null
         ]
         expect(sortByKeys(input)).toEqual(expected)
       })

--- a/src/lib/utilities/__tests__/String.test.ts
+++ b/src/lib/utilities/__tests__/String.test.ts
@@ -121,6 +121,150 @@ describe('utilities', () => {
         ]
         expect(sortByKeys(input)).toEqual(expected)
       })
+
+      it('handles deeply nested objects with arrays', () => {
+        const input = {
+          users: [
+            {
+              name: 'Charlie',
+              roles: ['admin', 'user'],
+              permissions: { // eslint-disable-line sort-keys
+                read: true,
+                write: false
+              }
+            },
+            {
+              name: 'Alice',
+              roles: ['user'],
+              permissions: { // eslint-disable-line sort-keys
+                read: true,
+                write: true
+              }
+            }
+          ],
+          settings: { // eslint-disable-line sort-keys
+            features: {
+              enabled: ['auth', 'logging'],
+              disabled: ['analytics'] // eslint-disable-line sort-keys
+            }
+          }
+        }
+        const expected = {
+          settings: {
+            features: {
+              disabled: ['analytics'],
+              enabled: ['auth', 'logging']
+            }
+          },
+          users: [
+            {
+              name: 'Charlie',
+              permissions: {
+                read: true,
+                write: false
+              },
+              roles: ['admin', 'user']
+            },
+            {
+              name: 'Alice',
+              permissions: {
+                read: true,
+                write: true
+              },
+              roles: ['user']
+            }
+          ]
+        }
+        expect(sortByKeys(input)).toEqual(expected)
+      })
+
+      it('handles arrays nested within arrays', () => {
+        const input = [
+          [
+            { name: 'Charlie', age: 30 }, // eslint-disable-line sort-keys
+            { name: 'Alice', age: 25 } // eslint-disable-line sort-keys
+          ],
+          [
+            { name: 'Bob', age: 28 } // eslint-disable-line sort-keys
+          ]
+        ]
+        const expected = [
+          [
+            { age: 30, name: 'Charlie' },
+            { age: 25, name: 'Alice' }
+          ],
+          [
+            { age: 28, name: 'Bob' }
+          ]
+        ]
+        expect(sortByKeys(input)).toEqual(expected)
+      })
+
+      it('handles complex mixed structures', () => {
+        const input = {
+          data: [
+            {
+              id: 1,
+              items: [
+                { name: 'Item A', value: 100 },
+                { name: 'Item B', value: 200 }
+              ],
+              metadata: {
+                created: '2024-01-01',
+                tags: ['important', 'urgent']
+              }
+            },
+            {
+              id: 2,
+              items: [
+                { name: 'Item C', value: 300 }
+              ],
+              metadata: {
+                created: '2024-01-02',
+                tags: ['normal']
+              }
+            }
+          ],
+          config: { // eslint-disable-line sort-keys
+            options: {
+              enabled: true,
+              features: ['feature1', 'feature2']
+            }
+          }
+        }
+        const expected = {
+          config: {
+            options: {
+              enabled: true,
+              features: ['feature1', 'feature2']
+            }
+          },
+          data: [
+            {
+              id: 1,
+              items: [
+                { name: 'Item A', value: 100 },
+                { name: 'Item B', value: 200 }
+              ],
+              metadata: {
+                created: '2024-01-01',
+                tags: ['important', 'urgent']
+              }
+            },
+            {
+              id: 2,
+              items: [
+                { name: 'Item C', value: 300 }
+              ],
+              metadata: {
+                created: '2024-01-02',
+                tags: ['normal']
+              }
+            }
+          ]
+        }
+        expect(sortByKeys(input)).toEqual(expected)
+      })
     })
   })
 })

--- a/src/lib/utilities/__tests__/String.test.ts
+++ b/src/lib/utilities/__tests__/String.test.ts
@@ -43,9 +43,17 @@ describe('utilities', () => {
         expect(sortByKeys(input)).toEqual(expected)
       })
 
-      it('sorts arrays objects', () => {
-        const input = [{ d: { b: 2, a: 1 } }, { c: 3 }] // eslint-disable-line sort-keys
-        const expected = [{ c: 3 }, { d: { a: 1, b: 2 } }]
+      it('preserves array element order while sorting object keys', () => {
+        const input = [
+          { name: 'Charlie', age: 30 }, // eslint-disable-line sort-keys
+          { name: 'Alice', age: 25 }, // eslint-disable-line sort-keys
+          { name: 'Bob', age: 28 } // eslint-disable-line sort-keys
+        ]
+        const expected = [
+          { age: 30, name: 'Charlie' }, // eslint-disable-line sort-keys
+          { age: 25, name: 'Alice' }, // eslint-disable-line sort-keys
+          { age: 28, name: 'Bob' }, // eslint-disable-line sort-keys
+        ]
         expect(sortByKeys(input)).toEqual(expected)
       })
     })


### PR DESCRIPTION
When using the JSON formatter, I found that it re-orders elements in arrays. This no longer makes it simply a formatter of JSON data since arrays are inherently ordered. Hence, I propose that the Sort Keys functionality only sorts keys of objects within the entire JSON structure. We did not expect/realize this when using `string-is`, which led to confusion.

In addition, the existing code sorts elements in an array via a string representation of each element, which feels like somewhat esoteric behavior for users of the formatter to understand, even if they wanted an array sorted in some fashion.

## How to test the PR
See unit tests

## Checklist

- [x] New functionality has tests.
- [x] README has been updated (if necessary).
- [x] New environment variables have been added to `.env.example` (if necessary).
