### PR TITLE
Regex optional groups crash

### DIFF
--- a/src/components/domain/convert/outputs/RegexOutput.tsx
+++ b/src/components/domain/convert/outputs/RegexOutput.tsx
@@ -248,6 +248,8 @@ export const RegexOutput = forwardRef<HTMLTextAreaElement, OutputProps>(
 
                   {groups.map((group, groupIndex) => {
                     const groupKey = `regexMatch-${matchIndex}-${groupIndex}`
+                    const safeGroup = group ?? ''
+                  
                     return (
                       <Label
                         htmlFor={groupKey}
@@ -261,7 +263,7 @@ export const RegexOutput = forwardRef<HTMLTextAreaElement, OutputProps>(
                           value={group}
                           width="100%"
                         />
-                        <CopyButton marginLeft={majorScale(1)} value={group} />
+                        <CopyButton marginLeft={majorScale(1)} value={safeGroup} />
                       </Label>
                     )
                   })}

--- a/src/lib/converters/__tests__/RegexDebugger.test.ts
+++ b/src/lib/converters/__tests__/RegexDebugger.test.ts
@@ -59,6 +59,24 @@ describe('converters', () => {
       })
     })
 
+    it('handles optional captured groups when not present', async () => {
+      await assertOutput(RegexDebugger, '/find (this)?/', async () => {
+        const inputElement = await screen.getByTestId('regex-input')
+        fireEvent.change(inputElement, {
+          target: { value: 'can you find ?' },
+        })
+
+        const matchOutput = await screen.getByTestId('regex-match-output')
+        expect(matchOutput.value).toEqual('find ')
+
+        const groupOutput = await screen.getByTestId('regex-group-output')
+        expect(groupOutput.value).toEqual('')
+
+        const alert = await screen.getByTestId('output-success')
+        expect(alert).toHaveTextContent('alert_single_match')
+      })
+    })
+
     it('reports an error if the input in invalid', async () => {
       await expectError(RegexDebugger, '(invalid!', 'alert_invalid_input')
     })


### PR DESCRIPTION
When an optional group was not present in the test string, 'group' was null and caused an exception to be thrown. Now we fall back to an empty string instead.

<img width="1138" height="538" alt="image" src="https://github.com/user-attachments/assets/c681fa71-22f1-465d-8791-9db6340e9a88" />

## How to test the PR

1. Open the regex debugger
2. Enter the pattern Hello(World)?$ in Box 1 (as suggested in issue #2002 )
3. Enter the string Hello in Box 2
4. No error is thrown, the string is shown to be a match, and the captured group is displayed
5. Additionally, it works with the test string HelloWorld


## Checklist

- [ x ] New functionality has tests.
- [ x ] README has been updated (if necessary). (N/A)
- [ x ] New environment variables have been added to `.env.example` (if necessary). (N/A)
